### PR TITLE
Intro: Fixed text break in Safari

### DIFF
--- a/static/sass/app/intro/_intro.scss
+++ b/static/sass/app/intro/_intro.scss
@@ -200,6 +200,10 @@
       }
     }
 
+    li {
+      break-inside: avoid;
+    }
+
     a {
       opacity: .8;
       color: $white;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/654171/43914474-4a651ec6-9c08-11e8-8bf1-499d528606d6.png)
