### PR TITLE
Bugfix: Content overflow on sponsorship pages

### DIFF
--- a/components/sponsors.js
+++ b/components/sponsors.js
@@ -121,7 +121,7 @@ class Sponsors extends Component {
                               <h3 className='sponsors__sponsor-name'>
                                 {item.title}
                               </h3>
-                              <p
+                              <div
                                 className='sponsors__sponsor-description'
                                 dangerouslySetInnerHTML={{
                                   __html: item.body

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ASSET_VERSION: '?v9',
+  ASSET_VERSION: '?v10',
   GA: 'UA-24147044-1',
   CONTENTFUL_SPACE: 'j8md9ikrag2j',
   // Read-only access and therefore not sensitive

--- a/static/sass/app/sponsors/_sponsors.scss
+++ b/static/sass/app/sponsors/_sponsors.scss
@@ -182,4 +182,12 @@
     width: 100%;
     align-self: center;
   }
+
+  &__link {
+    word-wrap: break-word;
+    
+    @media (max-width: $tablet) {
+      display: block;
+    }
+  }
 }


### PR DESCRIPTION
See https://twitter.com/sandrowuermli/status/1032226401762639872

The video issue on https://frontendconf.ch/sponsorship was fixed by adding a container in Contentful.